### PR TITLE
Add quick-copy icons to field labels

### DIFF
--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/CopyableLabel.tsx
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/CopyableLabel.tsx
@@ -9,6 +9,8 @@ interface CopyableLabelProps {
   label: string
   /** The value to copy to clipboard (defaults to label if not provided) */
   copyValue?: string
+  /** Whether to show the copy button (default: true) */
+  showCopyButton?: boolean
   /** Additional styles for the label container */
   style?: React.CSSProperties
 }
@@ -22,7 +24,7 @@ const TOOLTIP_RESET_DELAY = 2000
  * The icon appears to the right of the label text and is styled to be unobtrusive.
  */
 const CopyableLabel = (props: CopyableLabelProps) => {
-  const { label, copyValue, style } = props
+  const { label, copyValue, showCopyButton = true, style } = props
   const [copied, setCopied] = useState(false)
 
   const handleCopy = useCallback(async (e: React.MouseEvent) => {
@@ -49,29 +51,31 @@ const CopyableLabel = (props: CopyableLabelProps) => {
       ...style 
     }}>
       <Label style={{ flex: 1, marginBottom: 0 }}>{label}</Label>
-      <Tooltip title={copied ? TOOLTIP_COPIED : TOOLTIP_COPY} placement="top">
-        <button
-          type="button"
-          onClick={handleCopy}
-          aria-label={`Copy ${label} key`}
-          style={{
-            background: 'none',
-            border: 'none',
-            padding: '2px',
-            cursor: 'pointer',
-            opacity: 0.5,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            transition: 'opacity 0.2s ease',
-            marginLeft: '4px'
-          }}
-          onMouseEnter={(e) => { e.currentTarget.style.opacity = '1' }}
-          onMouseLeave={(e) => { e.currentTarget.style.opacity = '0.5' }}
-        >
-          <CopyOutlined size={12} color={copied ? '#10b981' : '#6b7280'} />
-        </button>
-      </Tooltip>
+      {showCopyButton && (
+        <Tooltip title={copied ? TOOLTIP_COPIED : TOOLTIP_COPY} placement="top">
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={`Copy ${label} key`}
+            style={{
+              background: 'none',
+              border: 'none',
+              padding: '2px',
+              cursor: 'pointer',
+              opacity: 0.5,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              transition: 'opacity 0.2s ease',
+              marginLeft: '4px'
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.opacity = '1' }}
+            onMouseLeave={(e) => { e.currentTarget.style.opacity = '0.5' }}
+          >
+            <CopyOutlined size={12} color={copied ? '#10b981' : '#6b7280'} />
+          </button>
+        </Tooltip>
+      )}
     </div>
   )
 }

--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/SourceConfigList.tsx
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/SourceConfigList.tsx
@@ -95,7 +95,8 @@ const SourceConfigList = (props: SourceConfigListProps) => {
         { label: MAP_TYPE_LABEL_HEATMAP, value: MapType.Heatmap },
         { label: MAP_TYPE_LABEL_INDOOR, value: MapType.Indoor }
       ],
-      defaultValue: MapType.Indoor
+      defaultValue: MapType.Indoor,
+      showCopyButton: false
     }
   ]
 
@@ -110,7 +111,7 @@ const SourceConfigList = (props: SourceConfigListProps) => {
       case FieldType.Text:
         return (
           <SettingRow key={field.key} flow={FlowType.Wrap}>
-            <CopyableLabel label={field.label} copyValue={`sourceConfigs[${index}].${field.key}`} />
+            <CopyableLabel label={field.label} copyValue={String(value || '')} showCopyButton={field.showCopyButton} />
             <TextInput
               style={{ width: '100%' }}
               value={value || ''}
@@ -123,7 +124,7 @@ const SourceConfigList = (props: SourceConfigListProps) => {
       case FieldType.Number:
         return (
           <SettingRow key={field.key} flow={FlowType.Wrap}>
-            <CopyableLabel label={field.label} copyValue={`sourceConfigs[${index}].${field.key}`} />
+            <CopyableLabel label={field.label} copyValue={String(value ?? '')} showCopyButton={field.showCopyButton} />
             <NumericInput
               style={{ width: '100%' }}
               value={value}
@@ -137,7 +138,7 @@ const SourceConfigList = (props: SourceConfigListProps) => {
       case FieldType.Switch:
         return (
           <SettingRow key={field.key} flow={FlowType.Wrap}>
-            <CopyableLabel label={field.label} copyValue={`sourceConfigs[${index}].${field.key}`} />
+            <CopyableLabel label={field.label} copyValue={String(value)} showCopyButton={field.showCopyButton} />
             <Switch
               checked={value}
               onChange={(e) => onSourceConfigChange(index, field.key, e.target.checked)}
@@ -148,7 +149,7 @@ const SourceConfigList = (props: SourceConfigListProps) => {
       case FieldType.Enum:
         return (
           <SettingRow key={field.key} flow={FlowType.Wrap}>
-            <CopyableLabel label={field.label} copyValue={`sourceConfigs[${index}].${field.key}`} />
+            <CopyableLabel label={field.label} copyValue={String(value || field.defaultValue || '')} showCopyButton={field.showCopyButton} />
             <Select
               style={{ width: '100%' }}
               value={value || field.defaultValue}

--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/configs.ts
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/configs.ts
@@ -28,6 +28,7 @@ export interface FieldConfig {
   defaultValue?: string | number | boolean
   showWhen?: (config: IAudiomConfig) => boolean
   enumOptions?: Array<{ label: string; value: string }>
+  showCopyButton?: boolean
 }
 
 export interface ISourceConfig {

--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/setting.tsx
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/setting.tsx
@@ -85,10 +85,10 @@ const Setting = (props: AllWidgetSettingProps<IAudiomConfig>) => {
     { key: AudiomConfigKey.Title, label: 'Title', type: FieldType.Text, placeholder: 'Enter widget title' },
     { key: AudiomConfigKey.ApiKey, label: 'API Key', type: FieldType.Text, placeholder: 'Enter API key' },
     { key: AudiomConfigKey.BaseUrl, label: 'Audiom Server Base URL', type: FieldType.Text, placeholder: 'Enter Audiom server URL', defaultValue: DEFAULT_CONFIG.baseUrl },
-    { key: AudiomConfigKey.StepSize, label: 'Step Size', type: FieldType.Number, min: 0.1, defaultValue: DEFAULT_CONFIG.stepSize },
-    { key: AudiomConfigKey.ShowVisualMap, label: 'Show Visual Map', type: FieldType.Switch, defaultValue: DEFAULT_CONFIG.showVisualMap },
-    { key: AudiomConfigKey.ShowHeading, label: 'Show Heading', type: FieldType.Switch, defaultValue: DEFAULT_CONFIG.showHeading },
-    { key: AudiomConfigKey.Heading, label: 'Heading', type: FieldType.Number, min: 0, max: 360, defaultValue: DEFAULT_CONFIG.heading },
+    { key: AudiomConfigKey.StepSize, label: 'Step Size', type: FieldType.Number, min: 0.1, defaultValue: DEFAULT_CONFIG.stepSize, showCopyButton: false },
+    { key: AudiomConfigKey.ShowVisualMap, label: 'Show Visual Map', type: FieldType.Switch, defaultValue: DEFAULT_CONFIG.showVisualMap, showCopyButton: false },
+    { key: AudiomConfigKey.ShowHeading, label: 'Show Heading', type: FieldType.Switch, defaultValue: DEFAULT_CONFIG.showHeading, showCopyButton: false },
+    { key: AudiomConfigKey.Heading, label: 'Heading', type: FieldType.Number, min: 0, max: 360, defaultValue: DEFAULT_CONFIG.heading, showCopyButton: false },
     { key: AudiomConfigKey.SoundpackUrl, label: 'Soundpack URL', type: FieldType.Text, placeholder: 'Enter soundpack URL' }
   ]
 
@@ -105,7 +105,7 @@ const Setting = (props: AllWidgetSettingProps<IAudiomConfig>) => {
       case FieldType.Text:
         return (
           <SettingRow key={field.key} flow={FlowType.Wrap}>
-            <CopyableLabel label={field.label} copyValue={field.key} />
+            <CopyableLabel label={field.label} copyValue={String(value || '')} showCopyButton={field.showCopyButton} />
             <TextInput
               style={{ width: '100%' }}
               value={value || ''}
@@ -118,7 +118,7 @@ const Setting = (props: AllWidgetSettingProps<IAudiomConfig>) => {
       case FieldType.Number:
         return (
           <SettingRow key={field.key} flow={FlowType.Wrap}>
-            <CopyableLabel label={field.label} copyValue={field.key} />
+            <CopyableLabel label={field.label} copyValue={String(value ?? '')} showCopyButton={field.showCopyButton} />
             <NumericInput
               style={{ width: '100%' }}
               value={value}
@@ -132,7 +132,7 @@ const Setting = (props: AllWidgetSettingProps<IAudiomConfig>) => {
       case FieldType.Switch:
         return (
           <SettingRow key={field.key} flow={FlowType.Wrap}>
-            <CopyableLabel label={field.label} copyValue={field.key} />
+            <CopyableLabel label={field.label} copyValue={String(value)} showCopyButton={field.showCopyButton} />
             <Switch
               checked={value}
               onChange={(e) => onPropertyChange(field.key, e.target.checked)}
@@ -147,7 +147,7 @@ const Setting = (props: AllWidgetSettingProps<IAudiomConfig>) => {
     <div className="widget-setting-demo">
       <SettingSection title="Map Source">
         <SettingRow flow={FlowType.Wrap}>
-          <CopyableLabel label="Use Existing Map Widget" copyValue="useExistingMap" />
+          <CopyableLabel label="Use Existing Map Widget" copyValue={String(config?.useExistingMap ?? DEFAULT_CONFIG.useExistingMap)} showCopyButton={false} />
           <Switch
             checked={config?.useExistingMap ?? DEFAULT_CONFIG.useExistingMap}
             onChange={(e) => onPropertyChange('useExistingMap', e.target.checked)}
@@ -156,7 +156,7 @@ const Setting = (props: AllWidgetSettingProps<IAudiomConfig>) => {
 
         {(config?.useExistingMap ?? DEFAULT_CONFIG.useExistingMap) ? (
           <SettingRow flow={FlowType.Wrap}>
-            <CopyableLabel label="Select Map Widget" copyValue="existingMapId" />
+            <CopyableLabel label="Select Map Widget" copyValue={config?.existingMapId || ''} showCopyButton={false} />
             <MapWidgetSelector useMapWidgetIds={props.useMapWidgetIds} onSelect={onMapWidgetSelected} />
           </SettingRow>
         ) : null}


### PR DESCRIPTION
## Summary

Adds quick-copy functionality to field labels in the settings panel, allowing users to easily copy field values to the clipboard. This addresses truncation issues with read-only fields that previously required inspect-element to access full values.

Resolves #50

## Changes

### New Component
- **[CopyableLabel.tsx](ArcGIS/client/your-extensions/widgets/audiom/src/setting/CopyableLabel.tsx)**: A reusable label component with an unobtrusive copy icon
  - Small copy icon (12px) appears to the right of labels
  - Starts at 50% opacity, fully visible on hover
  - Tooltip shows "Copy to clipboard" / "Copied!" feedback
  - Copies actual field values (not keys) to clipboard
  - Optional `showCopyButton` prop to hide the icon for certain fields

### Updated Files
- **[configs.ts](ArcGIS/client/your-extensions/widgets/audiom/src/setting/configs.ts)**: Added `showCopyButton?: boolean` to `FieldConfig` interface
- **[setting.tsx](ArcGIS/client/your-extensions/widgets/audiom/src/setting/setting.tsx)**: Integrated `CopyableLabel` for all configurable fields
  - Copy button hidden for UI-centric fields (switches, map selector, etc.)
  - Copies actual values: text strings, numbers, booleans
- **[SourceConfigList.tsx](ArcGIS/client/your-extensions/widgets/audiom/src/setting/SourceConfigList.tsx)**: Integrated `CopyableLabel` for all source config fields
  - Copy button hidden for Map Type enum
  - Copies actual source configuration values

### Configuration
Copy buttons are **hidden** for:
- Use Existing Map Widget (UI control)
- Select Map Widget (UI control)
- Step Size (simple numeric input)
- Show Visual Map (toggle)
- Show Heading (toggle)
- Heading (simple numeric input)
- Source Map Type (enum dropdown)

Copy buttons are **shown** for:
- Title, API Key, Base URL, Soundpack URL (important text fields)
- Center Latitude, Center Longitude, Zoom (map coordinates)
- All source config fields (Name, Source URL, Rules File URL, Source identifier)

## Benefits
- Eliminates need for inspect-element to copy truncated values
- Improves accessibility for long URLs and identifiers
- Maintains clean UI with unobtrusive hover-only icons
- Provides immediate visual feedback when values are copied

## Testing
- Copy icons appear next to appropriate field labels
- Clicking icon copies the actual field value to clipboard
- Tooltip feedback confirms successful copy
- Icons are hidden for specified UI-centric fields
- Copy works for text, numbers, and boolean values in all field types