### PR TITLE
Unify icon-action button visual style in Audiom settings

### DIFF
--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/CopyButton.tsx
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/CopyButton.tsx
@@ -1,34 +1,9 @@
-import { React, css } from 'jimu-core'
-import { Tooltip } from 'jimu-ui'
+import { React } from 'jimu-core'
 import { CopyOutlined } from 'jimu-icons/outlined/editor/copy'
 import { Colors } from '../enums'
 import { useCopyToClipboard } from '../useCopyToClipboard'
 import { TOOLTIP_COPY, TOOLTIP_COPIED } from '../strings'
-
-const copyButtonStyle = css({
-  padding: 2,
-  background: Colors.Transparent,
-  border: 'none',
-  cursor: 'pointer',
-  color: Colors.TextMuted,
-  opacity: 0.6,
-  transition: 'opacity 0.15s ease',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  '&:hover': {
-    opacity: 1
-  },
-  '&:focus-visible': {
-    outline: `2px solid ${Colors.FocusOutline}`,
-    outlineOffset: 1,
-    borderRadius: 2
-  },
-  '&:disabled': {
-    opacity: 0.3,
-    cursor: 'not-allowed'
-  }
-})
+import IconActionButton from './IconActionButton'
 
 export interface CopyButtonProps {
   /** The value to write to the clipboard */
@@ -45,32 +20,24 @@ export interface CopyButtonProps {
 
 /**
  * Small icon-only copy-to-clipboard button used across the settings UI.
- * Native <button> for accessibility; encapsulates the copied/idle state and styling.
+ * Built on the shared IconActionButton so the hit area, hover background,
+ * and focus ring match the other small actions (lock, visibility, trash, plus).
  */
 const CopyButton = (props: CopyButtonProps) => {
-  const { value, ariaLabel, iconSize = 12, disabled = false, stopPropagation = false } = props
+  const { value, ariaLabel, iconSize, disabled = false, stopPropagation = false } = props
   const { copied, copyToClipboard } = useCopyToClipboard()
 
-  const handleClick = (e: React.MouseEvent) => {
-    if (stopPropagation) {
-      e.preventDefault()
-      e.stopPropagation()
-    }
-    copyToClipboard(value)
-  }
-
   return (
-    <Tooltip title={copied ? TOOLTIP_COPIED : TOOLTIP_COPY} placement="top">
-      <button
-        type="button"
-        css={copyButtonStyle}
-        onClick={handleClick}
-        aria-label={ariaLabel}
-        disabled={disabled}
-      >
-        <CopyOutlined size={iconSize} color={copied ? Colors.Success : undefined} />
-      </button>
-    </Tooltip>
+    <IconActionButton
+      tooltip={copied ? TOOLTIP_COPIED : TOOLTIP_COPY}
+      ariaLabel={ariaLabel}
+      onClick={() => copyToClipboard(value)}
+      disabled={disabled}
+      stopPropagation={stopPropagation}
+      iconSize={iconSize}
+    >
+      <CopyOutlined color={copied ? Colors.Success : undefined} />
+    </IconActionButton>
   )
 }
 

--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/IconActionButton.tsx
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/IconActionButton.tsx
@@ -1,0 +1,113 @@
+import { React, css } from 'jimu-core'
+import { Button, Tooltip } from 'jimu-ui'
+import { ButtonSize, ButtonType } from '../enums'
+
+/**
+ * Standard square footprint for small icon-only action buttons.
+ * Matches stock ArcGIS Experience Builder widget chrome (Tertiary button hover background).
+ */
+const ICON_BUTTON_SIZE = 24
+const ICON_GLYPH_SIZE = 12
+
+const baseButtonStyle = css({
+  width: ICON_BUTTON_SIZE,
+  height: ICON_BUTTON_SIZE,
+  minWidth: ICON_BUTTON_SIZE,
+  padding: 0,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  '& svg': {
+    width: ICON_GLYPH_SIZE,
+    height: ICON_GLYPH_SIZE
+  }
+})
+
+const disabledStyle = css({
+  opacity: 0.3,
+  cursor: 'not-allowed'
+})
+
+export interface IconActionButtonProps {
+  /** Tooltip text. Also used for title/aria-label fallback. */
+  tooltip?: string
+  /** Accessible label. Falls back to tooltip when omitted. */
+  ariaLabel?: string
+  /** Click handler. Not invoked while disabled. */
+  onClick?: (e: React.MouseEvent) => void
+  /**
+   * Visually disable the button while keeping it focusable so the tooltip
+   * still appears on hover. Maps to aria-disabled and a muted style; click
+   * is suppressed.
+   */
+  disabled?: boolean
+  /** Mark the button as active (pressed/toggled on). */
+  active?: boolean
+  /** Stop click propagation (use when nested inside a clickable header). */
+  stopPropagation?: boolean
+  /** Optional override for inner glyph size (default 12px). */
+  iconSize?: number
+  /** The icon element. Sized via the `iconSize` prop or the default 12px. */
+  children: React.ReactNode
+}
+
+/**
+ * Shared icon-only action button used across the settings UI.
+ *
+ * Wraps Jimu's Tertiary `<Button icon size="sm">` in a fixed square footprint
+ * so heterogeneous glyphs (lock vs unlock, visible vs invisible, plus, trash,
+ * copy, expand/collapse) render with the same hit area, hover background, and
+ * focus ring — matching native EXB widgets.
+ */
+const IconActionButton = (props: IconActionButtonProps) => {
+  const {
+    tooltip,
+    ariaLabel,
+    onClick,
+    disabled = false,
+    active = false,
+    stopPropagation = false,
+    iconSize,
+    children
+  } = props
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (stopPropagation) {
+      e.stopPropagation()
+    }
+    if (disabled) {
+      e.preventDefault()
+      return
+    }
+    onClick?.(e)
+  }
+
+  const sizeOverrideStyle = iconSize !== undefined
+    ? css({ '& svg': { width: iconSize, height: iconSize } })
+    : undefined
+
+  const button = (
+    <Button
+      type={ButtonType.Tertiary}
+      size={ButtonSize.Small}
+      icon
+      active={active}
+      onClick={handleClick}
+      aria-label={ariaLabel ?? tooltip}
+      aria-disabled={disabled || undefined}
+      css={[baseButtonStyle, disabled && disabledStyle, sizeOverrideStyle]}
+    >
+      {children}
+    </Button>
+  )
+
+  if (!tooltip) return button
+
+  return (
+    <Tooltip title={tooltip} placement="top">
+      {button}
+    </Tooltip>
+  )
+}
+
+export default IconActionButton

--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/LockToggle.tsx
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/LockToggle.tsx
@@ -1,15 +1,7 @@
-import { React, css } from 'jimu-core'
-import { Button, Tooltip } from 'jimu-ui'
+import { React } from 'jimu-core'
 import { LockOutlined } from 'jimu-icons/outlined/editor/lock'
 import { UnlockOutlined } from 'jimu-icons/outlined/editor/unlock'
-import { ButtonSize, ButtonType } from '../enums'
-
-const lockButtonStyle = css({
-  padding: 2,
-  minWidth: 'auto',
-  background: 'transparent',
-  border: 'none'
-})
+import IconActionButton from './IconActionButton'
 
 export interface LockToggleProps {
   /** Whether the field is currently locked (synced with map) */
@@ -27,34 +19,27 @@ export interface LockToggleProps {
 }
 
 /**
- * Lock/Unlock toggle button shared across settings UI.
- * Tooltip + aria-label switch with state. Caller supplies both strings
- * so different contexts (latitude, filter, source visibility) can localize.
+ * Lock/Unlock toggle button shared across the settings UI.
+ * Built on IconActionButton so the locked and unlocked glyphs share the
+ * same square footprint (eliminating the rectangular look caused by the
+ * wider unlock icon) and match other small action buttons.
  */
 const LockToggle = (props: LockToggleProps) => {
-  const { locked, onToggle, unlockTooltip, lockTooltip, iconSize = 12, stopPropagation = false } = props
+  const { locked, onToggle, unlockTooltip, lockTooltip, iconSize, stopPropagation = false } = props
   const tooltip = locked ? unlockTooltip : lockTooltip
   const Icon = locked ? LockOutlined : UnlockOutlined
 
-  const handleClick = (e: React.MouseEvent) => {
-    if (stopPropagation) {
-      e.stopPropagation()
-    }
-    onToggle()
-  }
-
   return (
-    <Tooltip title={tooltip}>
-      <Button
-        type={ButtonType.Tertiary}
-        size={ButtonSize.Small}
-        onClick={handleClick}
-        aria-label={tooltip}
-        css={lockButtonStyle}
-      >
-        <Icon size={iconSize} />
-      </Button>
-    </Tooltip>
+    <IconActionButton
+      tooltip={tooltip}
+      ariaLabel={tooltip}
+      onClick={onToggle}
+      stopPropagation={stopPropagation}
+      active={locked}
+      iconSize={iconSize}
+    >
+      <Icon />
+    </IconActionButton>
   )
 }
 

--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/SourceConfigCard.tsx
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/SourceConfigCard.tsx
@@ -1,4 +1,4 @@
-import { React, css } from 'jimu-core'
+import { React } from 'jimu-core'
 import { Card, Collapse, Button, ButtonGroup, Tooltip, TextInput } from 'jimu-ui'
 import { SettingRow } from 'jimu-ui/advanced/setting-components'
 import { VisibleOutlined } from 'jimu-icons/outlined/application/visible'
@@ -7,7 +7,7 @@ import { TrashOutlined } from 'jimu-icons/outlined/editor/trash'
 import { PlusOutlined } from 'jimu-icons/outlined/editor/plus'
 import { MapType } from '../../../../../shared/audiom-client/AudiomSource'
 import { DEFAULT_SOURCE_CONFIG, DEFAULT_FILTER_CONFIG, FieldConfig, ISourceConfig, IFilterConfig, MAP_TYPE_OPTIONS } from '../configs'
-import { ButtonSize, ButtonType, FieldType, FlowType, Colors, FilterType } from '../enums'
+import { ButtonSize, FieldType, FlowType, Colors, FilterType } from '../enums'
 import { SourceConfigKey } from '../configKeys'
 import { validateUrl } from '../validation/validation'
 import { replaceAt } from '../../utils/sourceConfigUtils'
@@ -15,6 +15,7 @@ import CollapsibleHeader, { CollapsibleHeaderLevel } from './CollapsibleHeader'
 import CopyableLabel from './CopyableLabel'
 import CopyButton from './CopyButton'
 import LockToggle from './LockToggle'
+import IconActionButton from './IconActionButton'
 import FieldRenderer from './FieldRenderer'
 
 // Typed styles with full key/value validation
@@ -52,28 +53,6 @@ const styles = {
     marginBottom: 2
   }
 } as const satisfies Record<string, React.CSSProperties>
-
-const filterActionButtonStyle = css({
-  padding: 2,
-  minWidth: 20,
-  minHeight: 20,
-  '& svg': {
-    width: 12,
-    height: 12
-  }
-})
-
-const filterActionDisabledStyle = css({
-  padding: 2,
-  minWidth: 20,
-  minHeight: 20,
-  opacity: 0.3,
-  cursor: 'not-allowed',
-  '& svg': {
-    width: 12,
-    height: 12
-  }
-})
 
 // UI text — see ../strings.ts for the canonical home of these strings.
 import {
@@ -173,19 +152,14 @@ const FilterItem = (props: {
           disabled={!expression}
         />
         {/* Delete */}
-        <Tooltip title={TOOLTIP_REMOVE_FILTER}>
-          <Button
-            size={ButtonSize.Small}
-            type={ButtonType.Tertiary}
-            icon
-            css={canDelete ? filterActionButtonStyle : filterActionDisabledStyle}
-            onClick={() => canDelete && onRemove(filterIndex)}
-            aria-label={`${TOOLTIP_REMOVE_FILTER} ${filterIndex + 1}`}
-            aria-disabled={!canDelete}
-          >
-            <TrashOutlined />
-          </Button>
-        </Tooltip>
+        <IconActionButton
+          tooltip={TOOLTIP_REMOVE_FILTER}
+          ariaLabel={`${TOOLTIP_REMOVE_FILTER} ${filterIndex + 1}`}
+          onClick={() => onRemove(filterIndex)}
+          disabled={!canDelete}
+        >
+          <TrashOutlined />
+        </IconActionButton>
       </div>
       <TextInput
         style={{ width: '100%' }}
@@ -305,56 +279,42 @@ const SourceConfigCard = (props: SourceConfigCardProps) => {
               stopPropagation
             />
           </span>
-          <Tooltip title={isEnabled ? TOOLTIP_HIDE : TOOLTIP_SHOW}>
-            <Button
-              size={ButtonSize.Small}
-              type={ButtonType.Tertiary}
-              icon
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation()
-                onToggleEnabled()
-              }}
-              aria-label={isEnabled ? TOOLTIP_HIDE : TOOLTIP_SHOW}
-              style={{ marginLeft: '4px' }}
+          <span style={{ marginLeft: '4px', display: 'inline-flex' }}>
+            <IconActionButton
+              tooltip={isEnabled ? TOOLTIP_HIDE : TOOLTIP_SHOW}
+              ariaLabel={isEnabled ? TOOLTIP_HIDE : TOOLTIP_SHOW}
+              onClick={onToggleEnabled}
+              stopPropagation
+              active={!isEnabled}
             >
               {isEnabled ? <VisibleOutlined /> : <InvisibleOutlined />}
-            </Button>
-          </Tooltip>
+            </IconActionButton>
+          </span>
         </>
       )
     }
 
     return (
       <>
-        <Tooltip title={TOOLTIP_REMOVE}>
-          <Button
-            size={ButtonSize.Small}
-            type={ButtonType.Tertiary}
-            icon
-            onClick={(e: React.MouseEvent) => {
-              e.stopPropagation()
-              onRemove()
-            }}
-            aria-label={`${TOOLTIP_REMOVE} ${sourceName}`}
-          >
-            <TrashOutlined />
-          </Button>
-        </Tooltip>
-        <Tooltip title={isEnabled ? TOOLTIP_HIDE : TOOLTIP_SHOW}>
-          <Button
-            size={ButtonSize.Small}
-            type={ButtonType.Tertiary}
-            icon
-            onClick={(e: React.MouseEvent) => {
-              e.stopPropagation()
-              onToggleEnabled()
-            }}
-            aria-label={isEnabled ? TOOLTIP_HIDE : TOOLTIP_SHOW}
-            style={{ marginLeft: '4px' }}
+        <IconActionButton
+          tooltip={TOOLTIP_REMOVE}
+          ariaLabel={`${TOOLTIP_REMOVE} ${sourceName}`}
+          onClick={onRemove}
+          stopPropagation
+        >
+          <TrashOutlined />
+        </IconActionButton>
+        <span style={{ marginLeft: '4px', display: 'inline-flex' }}>
+          <IconActionButton
+            tooltip={isEnabled ? TOOLTIP_HIDE : TOOLTIP_SHOW}
+            ariaLabel={isEnabled ? TOOLTIP_HIDE : TOOLTIP_SHOW}
+            onClick={onToggleEnabled}
+            stopPropagation
+            active={!isEnabled}
           >
             {isEnabled ? <VisibleOutlined /> : <InvisibleOutlined />}
-          </Button>
-        </Tooltip>
+          </IconActionButton>
+        </span>
       </>
     )
   }
@@ -427,19 +387,15 @@ const SourceConfigCard = (props: SourceConfigCardProps) => {
             stopPropagation
           />
         )}
-        <Tooltip title={TOOLTIP_ADD_FILTER}>
-          <Button
-            size={ButtonSize.Small}
-            type={ButtonType.Tertiary}
-            icon
-            css={canAdd ? filterActionButtonStyle : filterActionDisabledStyle}
-            onClick={(e: React.MouseEvent) => { e.stopPropagation(); canAdd && onAddFilter() }}
-            aria-label={TOOLTIP_ADD_FILTER}
-            aria-disabled={!canAdd}
-          >
-            <PlusOutlined />
-          </Button>
-        </Tooltip>
+        <IconActionButton
+          tooltip={TOOLTIP_ADD_FILTER}
+          ariaLabel={TOOLTIP_ADD_FILTER}
+          onClick={onAddFilter}
+          disabled={!canAdd}
+          stopPropagation
+        >
+          <PlusOutlined />
+        </IconActionButton>
       </div>
     )
 

--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/SourceConfigList.tsx
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/SourceConfigList.tsx
@@ -1,6 +1,6 @@
 import { React } from 'jimu-core'
 import { SettingRow } from 'jimu-ui/advanced/setting-components'
-import { Select, Option, Collapse, Button, Tooltip, TextInput } from 'jimu-ui'
+import { Select, Option, Collapse, Button, TextInput } from 'jimu-ui'
 import { ExpandAllOutlined } from 'jimu-icons/outlined/directional/expand-all'
 import { CollapseAllOutlined } from 'jimu-icons/outlined/directional/collapse-all'
 import { MapType } from '../../../../../shared/audiom-client/AudiomSource'
@@ -9,6 +9,7 @@ import { DEFAULT_SOURCE_CONFIG, ISourceConfig, MAP_TYPE_OPTIONS } from '../confi
 import { replaceAt } from '../../utils/sourceConfigUtils'
 import CopyableLabel from './CopyableLabel'
 import CollapsibleHeader from './CollapsibleHeader'
+import IconActionButton from './IconActionButton'
 import SourceConfigCard from './SourceConfigCard'
 
 const { useState, useEffect, useMemo } = React
@@ -201,28 +202,20 @@ const SourceConfigList = (props: SourceConfigListProps) => {
             <div style={styles.mapTypeRow}>
               <CopyableLabel label={FIELD_LABEL_ALL_MAP_TYPE} copyValue={''} showCopyButton={false} />
               <div style={styles.buttonGroup}>
-                <Tooltip title={TOOLTIP_EXPAND_ALL}>
-                  <Button
-                    size={ButtonSize.Small}
-                    type={ButtonType.Tertiary}
-                    icon
-                    onClick={expandAllSources}
-                    aria-label={TOOLTIP_EXPAND_ALL}
-                  >
-                    <ExpandAllOutlined />
-                  </Button>
-                </Tooltip>
-                <Tooltip title={TOOLTIP_COLLAPSE_ALL}>
-                  <Button
-                    size={ButtonSize.Small}
-                    type={ButtonType.Tertiary}
-                    icon
-                    onClick={collapseAllSources}
-                    aria-label={TOOLTIP_COLLAPSE_ALL}
-                  >
-                    <CollapseAllOutlined />
-                  </Button>
-                </Tooltip>
+                <IconActionButton
+                  tooltip={TOOLTIP_EXPAND_ALL}
+                  ariaLabel={TOOLTIP_EXPAND_ALL}
+                  onClick={expandAllSources}
+                >
+                  <ExpandAllOutlined />
+                </IconActionButton>
+                <IconActionButton
+                  tooltip={TOOLTIP_COLLAPSE_ALL}
+                  ariaLabel={TOOLTIP_COLLAPSE_ALL}
+                  onClick={collapseAllSources}
+                >
+                  <CollapseAllOutlined />
+                </IconActionButton>
               </div>
             </div>
             <Select

--- a/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/VisualBaseLayerCard.tsx
+++ b/ArcGIS/client/your-extensions/widgets/audiom/src/setting/components/VisualBaseLayerCard.tsx
@@ -1,13 +1,13 @@
 import { React } from 'jimu-core'
-import { Card, Collapse, TextInput, Tooltip, Button } from 'jimu-ui'
+import { Card, Collapse, TextInput } from 'jimu-ui'
 import { TrashOutlined } from 'jimu-icons/outlined/editor/trash'
 import { IVisualBaseLayerConfig } from '../configs'
-import { ButtonSize, ButtonType, Colors } from '../enums'
 import { Padding } from '../enums'
 import { validateUrl } from '../validation/validation'
 import CollapsibleHeader, { CollapsibleHeaderLevel } from './CollapsibleHeader'
 import CopyableLabel from './CopyableLabel'
 import GeoQuadEditor from './GeoQuadEditor'
+import IconActionButton from './IconActionButton'
 
 const { useCallback } = React
 
@@ -65,16 +65,14 @@ const VisualBaseLayerCard = (props: VisualBaseLayerCardProps) => {
 
   const actions = (
     <div style={styles.actions}>
-      <Tooltip title={TOOLTIP_REMOVE}>
-        <Button
-          type={ButtonType.Tertiary}
-          size={ButtonSize.Small}
-          onClick={(e: React.MouseEvent) => { e.stopPropagation(); onRemove() }}
-          aria-label={`${TOOLTIP_REMOVE} ${index + 1}`}
-        >
-          <TrashOutlined size={12} />
-        </Button>
-      </Tooltip>
+      <IconActionButton
+        tooltip={TOOLTIP_REMOVE}
+        ariaLabel={`${TOOLTIP_REMOVE} ${index + 1}`}
+        onClick={onRemove}
+        stopPropagation
+      >
+        <TrashOutlined />
+      </IconActionButton>
     </div>
   )
 

--- a/ArcGIS/server/public/apps/5/info.json
+++ b/ArcGIS/server/public/apps/5/info.json
@@ -2,7 +2,7 @@
   "created": 1770161674847,
   "description": "",
   "id": "5",
-  "modified": 1770164865242,
+  "modified": 1776808443531,
   "owner": "scionofdesign@gmail.com",
   "tags": [],
   "thumbnail": null,
@@ -15,10 +15,10 @@
     "JavaScript",
     "status: Draft",
     "version:1.19.0",
-    "modified: 1770164865241"
+    "modified: 1776808443529"
   ],
   "portalUrl": "https://xrnavigation.maps.arcgis.com",
   "username": "scionofdesign@gmail.com",
-  "name": "Untitled experience 1",
+  "name": "My Audiom Map",
   "isLocalApp": true
 }

--- a/ArcGIS/server/public/apps/5/resources/config/config.json
+++ b/ArcGIS/server/public/apps/5/resources/config/config.json
@@ -258,16 +258,16 @@
           "widgetId": "widget_1",
           "bbox": {
             "left": "0.0%",
-            "right": "50.00%",
+            "right": "0.0%",
             "top": "0.0%",
             "bottom": "0.0%",
-            "width": "100.0%",
+            "width": "50.00%",
             "height": "100.0%"
           },
           "setting": {
             "autoProps": {
-              "right": false,
-              "left": true,
+              "right": true,
+              "left": false,
               "top": true,
               "bottom": false
             },
@@ -1082,42 +1082,74 @@
             "source": "19c06d1cbae-layer-3",
             "sourceUrl": "https://services7.arcgis.com/HDgMIJDCbHtnomY9/ArcGIS/rest/services/ArcGIS_Indoors_Sample_Data_WFL1/FeatureServer/4",
             "mapType": "indoor",
-            "enabled": false
+            "filters": [],
+            "enabled": false,
+            "rulesFileUrl": "/rules/esri-indoor.json",
+            "locked": true
           },
           {
             "name": "Facilities",
             "source": "19c06d1cbaf-layer-4",
             "sourceUrl": "https://services7.arcgis.com/HDgMIJDCbHtnomY9/ArcGIS/rest/services/ArcGIS_Indoors_Sample_Data_WFL1/FeatureServer/3",
             "mapType": "indoor",
-            "enabled": false
+            "filters": [],
+            "enabled": false,
+            "rulesFileUrl": "/rules/esri-indoor.json"
           },
           {
             "name": "Levels",
             "source": "19c06d1cbaf-layer-5",
             "sourceUrl": "https://services7.arcgis.com/HDgMIJDCbHtnomY9/ArcGIS/rest/services/ArcGIS_Indoors_Sample_Data_WFL1/FeatureServer/2",
             "mapType": "indoor",
-            "enabled": true
+            "filters": [
+              {
+                "expression": "LEVEL_ID = '{BAE9BBC5-D74F-4B7A-9904-9763AE70CCF2}'",
+                "mapExpression": "LEVEL_ID = '{BAE9BBC5-D74F-4B7A-9904-9763AE70CCF2}'",
+                "filterType": "where",
+                "mapFilterType": "where",
+                "locked": true,
+                "fromMap": true
+              }
+            ],
+            "enabled": true,
+            "rulesFileUrl": "/rules/esri-indoor.json",
+            "filtersLocked": true
           },
           {
             "name": "Units",
             "source": "19c06d1cbaf-layer-6",
             "sourceUrl": "https://services7.arcgis.com/HDgMIJDCbHtnomY9/ArcGIS/rest/services/ArcGIS_Indoors_Sample_Data_WFL1/FeatureServer/1",
             "mapType": "indoor",
-            "enabled": true
+            "filters": [
+              {
+                "expression": "LEVEL_ID = '{BAE9BBC5-D74F-4B7A-9904-9763AE70CCF2}'",
+                "mapExpression": "LEVEL_ID = '{BAE9BBC5-D74F-4B7A-9904-9763AE70CCF2}'",
+                "filterType": "where",
+                "mapFilterType": "where",
+                "locked": true,
+                "fromMap": true
+              }
+            ],
+            "enabled": true,
+            "rulesFileUrl": "/rules/esri-indoor.json"
           },
           {
             "name": "Details",
             "source": "19c06d1cbb0-layer-7",
             "sourceUrl": "https://services7.arcgis.com/HDgMIJDCbHtnomY9/ArcGIS/rest/services/ArcGIS_Indoors_Sample_Data_WFL1/FeatureServer/0",
             "mapType": "indoor",
-            "enabled": false
+            "filters": [],
+            "enabled": false,
+            "rulesFileUrl": "/rules/esri-indoor.json"
           }
         ],
         "title": "Esri Building",
-        "centerLatitude": 34.056702128522275,
-        "centerLongitude": -117.19503563211973,
-        "zoom": 21,
-        "apiKey": "wO35blaGsjJREGuXehqWU"
+        "centerLatitude": 34.05669873354544,
+        "centerLongitude": -117.19468783901752,
+        "zoom": 19.91935483870236,
+        "apiKey": "wO35blaGsjJREGuXehqWU",
+        "titleLocked": true,
+        "centerLongitudeLocked": true
       },
       "id": "widget_23",
       "useMapWidgetIds": [
@@ -1321,9 +1353,10 @@
   },
   "publishTimestamp": 1761630908582,
   "attributes": {
-    "portalUrl": "https://xrnavigation.maps.arcgis.com"
+    "portalUrl": "https://xrnavigation.maps.arcgis.com",
+    "enableA11yForWidgetSettings": false
   },
-  "timestamp": 1770164865193,
+  "timestamp": 1776808443494,
   "sharedThemeVariables": null,
   "mainLocale": "en",
   "dataSources": {


### PR DESCRIPTION
Closes #75.

## Summary
Unifies the visual style of small icon-only action buttons across the Audiom widget settings UI. Introduces a single shared primitive `IconActionButton` (built on Jimu Tertiary `Button`, fixed 24×24 square footprint, 12px glyph) and refactors all icon actions to use it.

## Changes
- **New** `src/setting/components/IconActionButton.tsx` — shared primitive. Wraps Jimu `<Button type="tertiary" size="sm" icon>` in a fixed 24×24 footprint with a 12px inner SVG. Props: `tooltip`, `ariaLabel`, `onClick`, `disabled`, `active`, `stopPropagation`, `iconSize`. Disabled state preserves the `aria-disabled` + muted-style + guarded-click pattern so tooltips still appear on disabled hover.
- **Refactor** `CopyButton.tsx` — now wraps `IconActionButton`. Drops bespoke native `<button>`, `copyButtonStyle`, and custom focus outline. Preserves the green-flash on copy and the `TOOLTIP_COPY` ↔ `TOOLTIP_COPIED` swap.
- **Refactor** `LockToggle.tsx` — now wraps `IconActionButton`. Drops `lockButtonStyle`. Lock and Unlock glyphs now share the exact 24×24 hit area, fixing the rectangular look caused by the wider unlock glyph. Sets `active={locked}` so the EXB toggle treatment renders.
- **Refactor** `SourceConfigCard.tsx` — replaces inline `<Tooltip><Button icon>` blocks for Visibility (both `readOnly` and edit branches), Source remove (Trash), Filter group add (Plus), and per-filter delete (Trash). Removes the local `filterActionButtonStyle` / `filterActionDisabledStyle`.
- **Refactor** `SourceConfigList.tsx` — replaces expand-all and collapse-all with `IconActionButton`.
- **Refactor** `VisualBaseLayerCard.tsx` — replaces inline remove (Trash) with `IconActionButton`.
- Removes now-unused `Tooltip`, `Button`, `ButtonType`, `css` imports from touched files.

## Out of scope
- Where/When `ButtonGroup` (intentional segmented control).
- The full-width primary "Add Source Configuration" / "Add Base Layer" CTAs.
- The GeoQuadEditor visual/text mode toggle (uses text glyphs, not icons).
- All `aria-label` strings preserved verbatim, so `getByRole`/`getByLabelText` based tests continue to pass.

## Verification
- `npx jest --testPathPatterns=widgets/audiom` → **11/11 suites, 150/150 tests pass**.
- `get_errors` clean on all touched files.
- Manual visual check expected: Lock/Unlock, Visibility, Copy, Trash, Plus all render at the same 24×24 square footprint with the same Jimu Tertiary hover background and focus ring.